### PR TITLE
GH-42: Update fullscreen option in graphics menu when fullscreen state is changed.

### DIFF
--- a/src/engine/app/sdl/sdl-window.cpp
+++ b/src/engine/app/sdl/sdl-window.cpp
@@ -257,45 +257,47 @@ void sdl_window::set_maximized(bool maximized)
 
 void sdl_window::set_fullscreen(bool fullscreen)
 {
-	if (fullscreen != m_fullscreen)
+	if (m_fullscreen == fullscreen)
 	{
-		if (fullscreen)
-		{
-			const SDL_DisplayMode* sdl_display_mode = nullptr;
-
-			if (const auto sdl_window_display_id = SDL_GetDisplayForWindow(m_internal_window); sdl_window_display_id)
-			{
-				sdl_display_mode = SDL_GetDesktopDisplayMode(sdl_window_display_id);
-			}
-
-			SDL_SetWindowFullscreenMode(m_internal_window, sdl_display_mode);
-		}
-
-		// Hide cursor if visible
-		const bool is_cursor_visible = SDL_CursorVisible();
-		if (is_cursor_visible)
-		{
-			SDL_HideCursor();
-		}
-
-		// Save global mouse position
-		math::fvec2 mouse_position = {};
-		SDL_GetGlobalMouseState(&mouse_position.x(), &mouse_position.y());
-
-		// Change fullscreen state
-		SDL_SetWindowFullscreen(m_internal_window, fullscreen);
-
-		// Restore global mouse position
-		SDL_WarpMouseGlobal(mouse_position.x(), mouse_position.y());
-
-		// Restore cursor visibility
-		if (is_cursor_visible)
-		{
-			SDL_ShowCursor();
-		}
-		
-		m_fullscreen = fullscreen;
+		return;
 	}
+
+	if (fullscreen)
+	{
+		const SDL_DisplayMode* sdl_display_mode = nullptr;
+
+		if (const auto sdl_window_display_id = SDL_GetDisplayForWindow(m_internal_window); sdl_window_display_id)
+		{
+			sdl_display_mode = SDL_GetDesktopDisplayMode(sdl_window_display_id);
+		}
+
+		SDL_SetWindowFullscreenMode(m_internal_window, sdl_display_mode);
+	}
+
+	// Hide cursor if visible
+	const bool is_cursor_visible = SDL_CursorVisible();
+	if (is_cursor_visible)
+	{
+		SDL_HideCursor();
+	}
+
+	// Save global mouse position
+	math::fvec2 mouse_position = {};
+	SDL_GetGlobalMouseState(&mouse_position.x(), &mouse_position.y());
+
+	// Change fullscreen state
+	SDL_SetWindowFullscreen(m_internal_window, fullscreen);
+
+	// Restore global mouse position
+	SDL_WarpMouseGlobal(mouse_position.x(), mouse_position.y());
+
+	// Restore cursor visibility
+	if (is_cursor_visible)
+	{
+		SDL_ShowCursor();
+	}
+		
+	m_fullscreen = fullscreen;
 }
 
 void sdl_window::set_v_sync(bool v_sync)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -72,6 +72,7 @@
 #include <engine/hash/fnv.hpp>
 #include <engine/utility/paths.hpp>
 #include <engine/ui/label.hpp>
+#include <engine/ui/range.hpp>
 #include <entt/entt.hpp>
 #include <filesystem>
 #include <functional>
@@ -915,6 +916,33 @@ void game::setup_ui()
 			
 			// Re-align debug text
 			frame_time_text->set_translation({std::round(0.0f), std::round(viewport_size.y() - debug_font->get_metrics().size), 99.0f});
+
+			if (m_graphics_menu_container)
+			{
+				// HACK: Find the fullscreen button based on the string of its label and click it
+				const auto fullscreen_string = get_string(*this, "graphics_menu_fullscreen");
+
+				std::shared_ptr<ui::element> fullscreen_button;
+				m_graphics_menu_container->visit_descendants
+				(
+					[&](auto& descendant)
+					{
+						if (descendant.get_type() == ui::element_type::label)
+						{
+							auto& label = static_cast<ui::label&>(descendant);
+							if (label.get_text() == fullscreen_string)
+							{
+								fullscreen_button = label.get_focus_right().lock();
+							}
+						}
+					}
+				);
+
+				if (fullscreen_button && fullscreen_button->get_type() == ui::element_type::range)
+				{
+					static_cast<ui::range&>(*fullscreen_button).set_value(window->is_fullscreen());
+				}
+			}
 		}
 	);
 	

--- a/src/game/menu.cpp
+++ b/src/game/menu.cpp
@@ -1369,6 +1369,11 @@ namespace
 		(
 			[&ctx](const auto& event)
 			{
+				if (ctx.window->is_fullscreen() == static_cast<bool>(event.value))
+				{
+					return true;
+				}
+
 				ctx.window->set_fullscreen(static_cast<bool>(event.value));
 				return ctx.window->is_fullscreen() == static_cast<bool>(event.value);
 			}


### PR DESCRIPTION
The fullscreen option in the graphics menu should now accurately display the fullscreen state after it has been changed via keyboard shortcuts.