### PR TITLE
GH-49: Make finding quaternion rotation between two vectors more robust.

### DIFF
--- a/src/engine/math/functions.hpp
+++ b/src/engine/math/functions.hpp
@@ -276,9 +276,9 @@ namespace engine::math::inline functions
 	/// @param x Floating-point value.
 	/// @return Inverse of the square root of @p x.
 	template <std::floating_point T>
-	[[nodiscard]] inline T inversesqrt(T x)
+	[[nodiscard]] inline T rcp_sqrt(T x)
 	{
-		return T{1} / sqrt(x);
+		return rcp(sqrt(x));
 	}
 
 	/// Returns the cube root of a value.

--- a/src/engine/math/quaternion-functions.hpp
+++ b/src/engine/math/quaternion-functions.hpp
@@ -363,10 +363,8 @@ namespace engine::math::inline functions
 
 		if (cos_theta <= T{-1} + tolerance)
 		{
-			// Vectors are opposing, return 180 degree rotation about an arbitrary perpendicular axis
-			const vec3<T> reference = (math::abs(from.x()) < T{1} - tolerance) ? vec3<T>{1, 0, 0} : vec3<T>{0, 1, 0};
-			const vec3<T> axis = normalize(cross(from, reference));
-			return angle_axis(math::pi<T>, axis);
+			// Vectors are opposing, return 180 degree rotation about an arbitrary orthogonal axis
+			return angle_axis(pi<T>, unit_orthogonal(from, tolerance));
 		}
 		else if (cos_theta >= T{1} - tolerance)
 		{
@@ -390,10 +388,8 @@ namespace engine::math::inline functions
 
 		if (cos_theta <= T{-1} + tolerance)
 		{
-			// Vectors are opposing, return max angle rotation about an arbitrary perpendicular axis
-			const vec3<T> reference = (math::abs(from.x()) < T{1} - tolerance) ? vec3<T>{1, 0, 0} : vec3<T>{0, 1, 0};
-			const vec3<T> axis = normalize(cross(from, reference));
-			return angle_axis(max_angle, axis);
+			// Vectors are opposing, return max angle rotation about an arbitrary orthogonal axis
+			return angle_axis(max_angle, unit_orthogonal(from, tolerance));
 		}
 		else if (cos_theta >= T{1} - tolerance)
 		{

--- a/src/engine/math/quaternion-functions.hpp
+++ b/src/engine/math/quaternion-functions.hpp
@@ -388,8 +388,8 @@ namespace engine::math::inline functions
 
 		if (cos_theta <= T{-1} + tolerance)
 		{
-			// Vectors are opposing, return max angle rotation about an arbitrary orthogonal axis
-			return angle_axis(max_angle, unit_orthogonal(from, tolerance));
+			// Vectors are opposing, return max angle (clamped to Pi) rotation about an arbitrary orthogonal axis
+			return angle_axis(min(pi<T>, max_angle), unit_orthogonal(from, tolerance));
 		}
 		else if (cos_theta >= T{1} - tolerance)
 		{

--- a/src/engine/math/vector-functions.hpp
+++ b/src/engine/math/vector-functions.hpp
@@ -537,6 +537,17 @@ namespace engine::math::inline functions
 		return dot(x, cross(y, z));
 	}
 
+	/// Finds a direction vector orthogonal to a given direction vector.
+	/// @param v Input direction vector.
+	/// @param tolerance Floating-point tolerance.
+	/// @return Direction vector orthogonal to @p v.
+	template <class T>
+	[[nodiscard]] inline vec3<T> unit_orthogonal(const vec3<T>& v, T tolerance = T{1e-6})
+	{
+		const vec3<T> reference = (abs(v.x()) < T{1} - tolerance) ? vec3<T>{1, 0, 0} : vec3<T>{0, 1, 0};
+		return normalize(cross(v, reference));
+	}
+
 	/// Calculates the square length of a vector. The square length can be calculated faster than the length because a call to `sqrt` is saved.
 	/// @param v Vector of which to calculate the square length.
 	/// @return Square length of the vector.

--- a/src/engine/render/passes/sky-pass.cpp
+++ b/src/engine/render/passes/sky-pass.cpp
@@ -365,7 +365,6 @@ namespace engine::render
 		}
 	
 		// Prevent stars from being drawn in front of the moon
-		m_pipeline->set_stencil_compare_mask(gl::stencil_face_front_and_back, 0xff);
 		m_pipeline->set_stencil_op
 		(
 			gl::stencil_face_front_and_back,

--- a/src/engine/script/script-math-module.cpp
+++ b/src/engine/script/script-math-module.cpp
@@ -183,7 +183,7 @@ namespace
 
 	auto lua_math_inversesqrt(lua_State* lua) -> int
 	{
-		const auto result = math::inversesqrt(luaL_checknumber(lua, 1));
+		const auto result = math::rcp_sqrt(luaL_checknumber(lua, 1));
 		lua_pop(lua, 1);
 		lua_pushnumber(lua, result);
 		debug::postcondition(lua_gettop(lua) == 1);

--- a/test/test-math.cpp
+++ b/test/test-math.cpp
@@ -705,5 +705,36 @@ int main(int, char*[])
 		ASSERT_EQ(str, "{-9999.9600, {0.0000, 0.6667, inf}}");
 	});
 
+	suite.tests.emplace_back("quaternion rotation", []()
+	{
+		const float tolerance = 1e-6f;
+
+		const fvec3 axes[][2] =
+		{
+			{{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}}, // Two perpendicular vectors
+			{{0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 1.0f}}, // Two identical vectors
+			{normalize(fvec3{1, 2, 3}), normalize(fvec3{5, -3, 2})}, // Two arbitrary vectors
+			{normalize(fvec3{10, 11, 1000}), normalize(fvec3{-50, -51, -52})}, // Two arbitrary vectors
+			{normalize(fvec3{1, 1, 0}), normalize(fvec3{0, 1, 1})}, // Two arbitrary vectors
+			{{1.0f, 0.0f, 0.0f}, {-1.0f, 0.0f, 0.0f}}, // Two opposing vectors (x-axis)
+			{{0.0f, -1.0f, 0.0f}, {0.0f, 1.0f, 0.0f}}, // Two opposing vectors (y-axis)
+			{{0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, -1.0f}}, // Two opposing vectors (z-axis)
+			{normalize(fvec3{-0.025f, 0.5f, -0.372f}), normalize(fvec3{0.025f, -0.5f, 0.372f})} // Two opposing vectors (arbitrary axis)
+		};
+
+		for (const auto& [a, b]: axes)
+		{
+			fvec3 c = rotation(a, b, tolerance) * a;
+			ASSERT_NEAR(c.x(), b.x(), tolerance);
+			ASSERT_NEAR(c.y(), b.y(), tolerance);
+			ASSERT_NEAR(c.z(), b.z(), tolerance);
+
+			c = rotate_towards(a, b, pi<float>, tolerance) * a;
+			ASSERT_NEAR(c.x(), b.x(), tolerance);
+			ASSERT_NEAR(c.y(), b.y(), tolerance);
+			ASSERT_NEAR(c.z(), b.z(), tolerance);
+		}
+	});
+
 	return suite.run();
 }


### PR DESCRIPTION
GH-49 was caused by `math::rotate_towards()` not properly handling parallel or near-parallel vectors, occasionally resulting in NaNs. This change makes finding the quaternion rotation between two vectors more robust by handling opposing and codirectional vectors.